### PR TITLE
Add missing return shape for withConsecutive()

### DIFF
--- a/src/ConsecutiveParams.php
+++ b/src/ConsecutiveParams.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 trait ConsecutiveParams
 {
+    /** @return list<Callback> */
     public static function withConsecutive(array $firstCallArguments, array ...$consecutiveCallsArguments): iterable
     {
         foreach ($consecutiveCallsArguments as $consecutiveCallArguments) {


### PR DESCRIPTION
Without this, SA tools are complaining as such:
```
Method PHPUnit\Framework\MockObject\Builder\InvocationMocker::with called with unpacked iterable iterable<mixed, mixed> with invalid key (must be int|string)
```